### PR TITLE
feat: adding .net6 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup dotnet 5.0.400
+      - name: Setup dotnet 5.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.400
+          dotnet-version: '5.0.x'
+
+      - name: Setup dotnet 6.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Build
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,10 +35,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup dotnet 5.0.400
+      - name: Setup dotnet 5.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.400
+          dotnet-version: '5.0.x'
+
+      - name: Setup dotnet 6.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Build
         shell: bash
@@ -61,10 +66,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup dotnet 5.0.400
+      - name: Setup dotnet 5.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.400
+          dotnet-version: '5.0.x'
+
+      - name: Setup dotnet 6.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Publish
         shell: bash

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "projects": ["src"],
+    "sdk": {
+        "version": "6.0.200",
+        "rollForward": "latestFeature"
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-    "projects": [ "src" ],
-    "sdk": {
-      "version": "5.0.400",
-      "rollForward": "latestFeature"
-    }
-  }

--- a/src/GetTheForkOut.csproj
+++ b/src/GetTheForkOut.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>get-the-fork-out</PackageId>
     <Nullable>enable</Nullable>
-    <LangVersion>9</LangVersion>
+    <LangVersion>latest</LangVersion>
     <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     <ToolCommandName>dotnet-get-the-fork-out</ToolCommandName>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
I wanted to run this tool, but I only have one SDK/runtime installed at a time on my machine, and currently it's net6.0. 

So,  I had a punt at adding support for multiple versions, you're exiting 5.x and now 6.x. 

This was the error I got when trying to build the project on the main branch btw:

```text
Could not execute because the application was not found or a compatible .NET SDK is not installed.
Possible reasons for this include:
  * You intended to execute a .NET program:
      The application 'build' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible installed .NET SDK for global.json version [5.0.400] from [/Users/solrevdev/Dropbox/Projects/github/get-the-fork-out/global.json] was not found.
      Install the [5.0.400] .NET SDK or update [/Users/solrevdev/Dropbox/Projects/github/get-the-fork-out/global.json] with an installed .NET SDK:
        6.0.200 [/usr/local/share/dotnet/sdk]
```